### PR TITLE
New test to exhibit a particular line-mode problem

### DIFF
--- a/test/source/app.d
+++ b/test/source/app.d
@@ -554,6 +554,16 @@ void testDiffMain() {
   auto texts_textmode = diff_rebuildtexts(diff_main(a, b, false));
   assertEquals(texts_textmode, texts_linemode);
 
+  // Test line-mode compression running out of UTF-8 space
+  import std.conv;
+  a = "";
+  b = "";
+  foreach (x; 0 .. 500) {
+      a ~= "1234567890" ~ to!string(x) ~ "\n";
+      b ~= "abcdefghij" ~ to!string(x) ~ "\n";
+  }
+  assertEquals(diff_main(a, b, false), diff_main(a, b, true));
+
   // (Don't) Test null inputs (not needed in D, because null is a valid empty string)
   //assertThrown(diff_main(null, null));
 }


### PR DESCRIPTION
Line-mode diff uses a type of compression to speed up.
As far as I understand it to this point, it assigns any unique line it finds in a or b to a single character, starting at 0x01.
It then runs the same diff code on the compressed strings, which generally works, except...
One problem with this is that it eventually is generating invalid UTF-8 characters. (I think it happens at 0x7F.)
Another problem with this is that if it didn't run into invalid UTF-8 while still 1 byte codepoints, it would run into issues with the general diff code chopping up the strings using just text1.length and text2.length, creating the possibility of cutting in the middle of a UTF-8 character.
Anyway, I've been hacking at this a bit, starting with changing the compression to start later into the UTF-8 space, but going down that road while require a fine tooth comb over the code chopping up the strings...
I wonder what you think of all this. I would like to contribute a bit more help if I can, but eventually I've got to move onto some other work.
Thanks!
Olivier