### PR TITLE
Fix deprecation warnings

### DIFF
--- a/source/ddmp/patch.d
+++ b/source/ddmp/patch.d
@@ -21,8 +21,10 @@
  * http://code.google.com/p/google-diff-match-patch/
  */
 module ddmp.patch;
+import std.algorithm : min, max;
 import std.array;
 import std.conv;
+import std.exception : enforce;
 import std.string:lastIndexOf;
 
 import ddmp.diff;


### PR DESCRIPTION
Fixes:
```
source/ddmp/patch.d(109,18): Deprecation: ddmp.diff.max is not visible from module patch
source/ddmp/patch.d(109,50): Deprecation: ddmp.diff.min is not visible from module patch
source/ddmp/patch.d(115,21): Deprecation: ddmp.diff.max is not visible from module patch
source/ddmp/patch.d(121,51): Deprecation: ddmp.diff.min is not visible from module patch
source/ddmp/patch.d(303,32): Deprecation: ddmp.diff.min is not visible from module patch
source/ddmp/patch.d(305,32): Deprecation: ddmp.diff.min is not visible from module patch
source/ddmp/patch.d(450,38): Deprecation: ddmp.diff.min is not visible from module patch
source/ddmp/patch.d(469,35): Deprecation: ddmp.diff.max is not visible from module patch
source/ddmp/patch.d(529,3): Deprecation: ddmp.diff.enforce is not visible from module patch
```

ddmp hasn't been updated for a long time, so I am calling for you, @s-ludwig. 