### PR TITLE
Add Meson build definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,22 @@
 language: d
 sudo: false
+dist: trusty
+
+before_install:
+  - pip3 install meson>=0.40
+
+install:
+  - mkdir .ntmp
+  - curl -L https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-linux.zip -o .ntmp/ninja-linux.zip
+  - unzip .ntmp/ninja-linux.zip -d .ntmp
+
+before_script:
+ - export PATH=$PATH:$PWD/.ntmp
 
 script:
   - dub test --compiler=${DC}
   - dub run --root=test --compiler=${DC}
+  - mkdir build && cd build
+  - meson ..
+  - ninja && ninja test
+  - DESTDIR=/tmp/target/ ninja install

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,62 @@
+project('ddmp', 'd',
+    meson_version: '>=0.42',
+    license: 'MIT',
+    version: '0.0.1'
+)
+
+project_soversion = '0'
+
+#
+# Dependencies
+#
+pkgc = import('pkgconfig')
+
+#
+# Sources
+#
+ddmp_src = [
+    'source/ddmp/match.d',
+    'source/ddmp/patch.d',
+    'source/ddmp/util.d',
+    'source/ddmp/diff.d'
+]
+
+src_dir = include_directories('source/')
+
+#
+# Targets
+#
+ddmp_lib = library('ddmp',
+        [ddmp_src],
+        include_directories: [src_dir],
+        install: true,
+        version: meson.project_version(),
+        soversion: project_soversion
+)
+pkgc.generate(name: 'ddmp',
+              libraries: ddmp_lib,
+              subdirs: 'd/ddmp',
+              version: meson.project_version(),
+              description: 'Diff-Patch-Match library for D.'
+)
+
+# to allow others to easily use this as a subproject
+ddmp_dep = declare_dependency(
+    link_with: [ddmp_lib],
+    include_directories: [src_dir]
+)
+
+#
+# Install
+#
+install_subdir('source/ddmp/', install_dir: 'include/d/ddmp/')
+
+#
+# Tests
+#
+ddmp_test_exe = executable('ddmp-test',
+        ['test/source/app.d'],
+        include_directories: [src_dir],
+        link_with: [ddmp_lib]
+)
+test('ddmp-test', ddmp_test_exe)


### PR DESCRIPTION
This is useful to use ddmp with projects using Meson, as well as Linux distro packaging.
I use this via fluent-asserts in a project, and having the Meson files upstream instead of in a downstream fork would be useful.

The tests for this PR fail because the tests are generally broken (maybe I can look into that later).