### PR TITLE
Bug: Files Larger than 128 Unique Lines Cause Malformed Diffs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig file: https://editorconfig.org/
+
+root = true
+
+# Default settings for all file types:
+# + save files in UTF-8 encoding
+# + remove whitespace at the end of lines
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# File type specific settings:
+[*.{d,di}]
+indent_style = space
+indent_size = 4

--- a/source/ddmp/diff.d
+++ b/source/ddmp/diff.d
@@ -31,23 +31,26 @@ import std.exception : enforce;
 import std.string : indexOf, endsWith, startsWith;
 import std.uni;
 import std.utf : toUTF16, toUTF8;
+import std.range : ElementEncodingType;
 import std.regex;
 import std.algorithm : min, max;
 import std.digest.sha;
+import std.traits : isSomeString;
 import core.time;
 
 
 Duration diffTimeout = 1.seconds;
 int DIFF_EDIT_COST = 4;
 
+alias Diff = DiffT!string;
 
 /**
 * Compute and return the source text (all equalities and deletions).
-* @param diffs List of Diff objects.
+* @param diffs List of DiffT objects.
 * @return Source text.
 */
-wstring diff_text1(Diff[] diffs) {
-    auto text = appender!wstring();
+Str diff_text1(Str)(DiffT!(Str)[] diffs) {
+    auto text = appender!Str();
     foreach ( d; diffs ) {
         if (d.operation != Operation.INSERT) {
             text.put(d.text);
@@ -58,11 +61,11 @@ wstring diff_text1(Diff[] diffs) {
 
 /**
 * Compute and return the destination text (all equalities and insertions).
-* @param diffs List of Diff objects.
+* @param diffs List of DiffT objects.
 * @return Destination text.
 */
-wstring diff_text2(Diff[] diffs) {
-    auto text = appender!wstring();
+Str diff_text2(Str)(DiffT!(Str)[] diffs) {
+    auto text = appender!Str();
     foreach ( d; diffs ) {
         if (d.operation != Operation.DELETE) {
             text.put(d.text);
@@ -75,10 +78,10 @@ wstring diff_text2(Diff[] diffs) {
 /**
  * Compute the Levenshtein distance; the number of inserted, deleted or
  * substituted characters.
- * @param diffs List of Diff objects.
+ * @param diffs List of DiffT objects.
  * @return Number of changes.
  */
-int levenshtein(Diff[] diffs) {
+int levenshtein(Str)(DiffT!(Str)[] diffs) {
     int levenshtein = 0;
     int insertions = 0;
     int deletions = 0;
@@ -109,25 +112,25 @@ int levenshtein(Diff[] diffs) {
  * E.g. =3\t-2\t+ing  -> Keep 3 chars, delete 2 chars, insert 'ing'.
  * Operations are tab-separated.  Inserted text is escaped using %xx
  * notation.
- * @param diffs Array of Diff objects.
+ * @param diffs Array of DiffT objects.
  * @return Delta text.
  */
-string toDelta(in Diff[] diffs)
+Str toDelta(Str)(in DiffT!(Str)[] diffs)
 {
     import std.range : walkLength;
     import std.format : formattedWrite;
     import std.uri : encode;
     auto text = appender!string;
-    foreach (aDiff; diffs) {
-        final switch (aDiff.operation) {
+    foreach (aDiffT; diffs) {
+        final switch (aDiffT.operation) {
             case Operation.INSERT:
-                text.formattedWrite("+%s\t", encode(aDiff.text).replace("%20", " "));
+                text.formattedWrite("+%s\t", encode(aDiffT.text).replace("%20", " "));
                 break;
             case Operation.DELETE:
-                text.formattedWrite("-%s\t", aDiff.text.walkLength);
+                text.formattedWrite("-%s\t", aDiffT.text.walkLength);
                 break;
             case Operation.EQUAL:
-                text.formattedWrite("=%s\t", aDiff.text.walkLength);
+                text.formattedWrite("=%s\t", aDiffT.text.walkLength);
                 break;
         }
     }
@@ -145,29 +148,29 @@ string toDelta(in Diff[] diffs)
  * operations required to transform text1 into text2, comAdde the full diff.
  * @param text1 Source string for the diff.
  * @param delta Delta text.
- * @return Array of Diff objects or null if invalid.
+ * @return Array of DiffT objects or null if invalid.
  * @throws ArgumentException If invalid input.
  */
-Diff[] fromDelta(string text1, string delta)
+DiffT!(Str)[] fromDelta(Str)(Str text1, Str delta)
 {
     import std.algorithm;
     import std.range;
     import std.string : format;
     import std.uri : decodeComponent;
 
-    auto diffs = appender!(Diff[]);
-    foreach (token; delta.splitter("\t")) {
+    auto diffs = appender!(DiffT!(Str)[]);
+    foreach (token; delta.splitter("\t".to!Str)) {
         if (token.length == 0) {
             // Blank tokens are ok (from a trailing \t).
             continue;
         }
         // Each token begins with a one character parameter which specifies the
         // operation of this token (delete, insert, equality).
-        string param = token[1 .. $];
+        Str param = token[1 .. $];
         switch (token[0]) {
             case '+':
                 // decode would change all "+" to " "
-                param = param.replace("+", "%2b");
+                param = param.replace("+".to!Str, "%2b".to!Str);
                 param = decodeComponent(param);
                 //} catch (UnsupportedEncodingException e) {
                 //  // Not likely on modern system.
@@ -177,7 +180,7 @@ Diff[] fromDelta(string text1, string delta)
                 //  throw new IllegalArgumentException(
                 //      "Illegal escape in diff_fromDelta: " + param, e);
                 //}
-                diffs ~= Diff(Operation.INSERT, param);
+                diffs ~= DiffT!Str(Operation.INSERT, param);
                 break;
             case '-': // Fall through.
             case '=':
@@ -194,9 +197,9 @@ Diff[] fromDelta(string text1, string delta)
                 text = text1.takeExactly(n).array.to!string;
                 text1.popFrontN(n);
                 if (token[0] == '=') {
-                    diffs ~= Diff(Operation.EQUAL, text);
+                    diffs ~= DiffT!Str(Operation.EQUAL, text);
                 } else {
-                    diffs ~= Diff(Operation.DELETE, text);
+                    diffs ~= DiffT!Str(Operation.DELETE, text);
                 }
                 break;
             default:
@@ -210,25 +213,22 @@ Diff[] fromDelta(string text1, string delta)
     return diffs.data;
 }
 
-struct LinesToCharsResult {
-    wstring text1;
-    wstring text2;
-    wstring[] uniqueStrings;
-    bool opEquals()(auto ref const LinesToCharsResult other) const {
-        return text1 == other.text1 && 
+alias LinesToCharsResult = LinesToCharsResultT!string;
+
+struct LinesToCharsResultT(Str) {
+    Str text1;
+    Str text2;
+    Str[] uniqueStrings;
+    bool opEquals()(auto ref const LinesToCharsResultT!Str other) const {
+        return text1 == other.text1 &&
                text2 == other.text2 &&
                uniqueStrings == other.uniqueStrings;
     }
 }
 
-LinesToCharsResult linesToChars(string text1, string text2) {
-    return linesToChars(toUTF16(text1), toUTF16(text2));
-}
-
-LinesToCharsResult linesToChars(wstring text1, wstring text2) 
-{
-    size_t[wstring] lineHash;
-    LinesToCharsResult res;
+LinesToCharsResultT!Str linesToChars(Str)(Str text1, Str text2) {
+    size_t[Str] lineHash;
+    LinesToCharsResultT!Str res;
     res.uniqueStrings = [""];
     res.text1 = linesToCharsMunge(text1, res.uniqueStrings, lineHash);
     res.text2 = linesToCharsMunge(text2, res.uniqueStrings, lineHash);
@@ -242,26 +242,33 @@ LinesToCharsResult linesToChars(wstring text1, wstring text2)
  * Finally, it returns a string with each UTF-16 character representing the unique line index for
  * each line of text in the original block of text.
  */
-wstring linesToCharsMunge(wstring text, ref wstring[] lines, ref size_t[wstring] linehash)
-{
+Str linesToCharsMunge(Str)(Str text, ref Str[] lines, ref size_t[Str] linehash)
+if (isSomeString!Str) {
     sizediff_t lineStart = 0;
     sizediff_t lineEnd = -1;
-    wstring line;
-    auto chars = appender!wstring();
+    Str line;
+    static if (is(ElementEncodingType!Str : char)) {
+      size_t lineLimit = 0x80;
+    } else {
+      size_t lineLimit = 0x0D800;
+    }
+    enforce(lines.length < lineLimit, "Algorithm unique line limit exceeded for "
+        ~ Str.stringof ~ ". string may use 127 lines, wstring/dstring may use 55295 lines.");
+    auto chars = appender!Str();
     while( lineEnd+1 < text.length ){
-        lineEnd = text.indexOfAlt("\n", lineStart);
+        lineEnd = text.indexOfAlt("\n".to!Str, lineStart);
         if( lineEnd == -1 ) lineEnd = text.length - 1;
         line = text[lineStart..lineEnd + 1];
         lineStart = lineEnd + 1;
 
         if (auto pv = line in linehash) {
-            chars ~= cast(wchar)*pv;
+            chars ~= cast(ElementEncodingType!Str)*pv;
         } else {
             lines ~= line;
             linehash[line] = lines.length - 1;
             // Using UTF-16, only values up to 0xD7FF (55295) can be represented before
             // encoding errors or multi-byte encodings are applied.
-            chars ~= cast(wchar)(lines.length -1);
+            chars ~= cast(ElementEncodingType!Str)(lines.length -1);
         }
     }
     return chars[];
@@ -271,12 +278,11 @@ wstring linesToCharsMunge(wstring text, ref wstring[] lines, ref size_t[wstring]
  * Reverses the process of [linesToChars] by interpretting each UTF-16 character as an index into
  * linesArray, and assembles the indexed lines into a block of text.
  */
-void charsToLines(Diff[] diffs, wstring[] lineArray)
-{
-    import std.stdio;
+void charsToLines(Str)(DiffT!Str[] diffs, Str[] lineArray)
+if (isSomeString!Str) {
     foreach (ref d; diffs) {
-        auto str = appender!wstring();
-        foreach (wchar ch; d.text) {
+        auto str = appender!Str();
+        foreach (ElementEncodingType!Str ch; d.text) {
             str.put(lineArray[ch]);
         }
         d.text = str[];
@@ -285,8 +291,8 @@ void charsToLines(Diff[] diffs, wstring[] lineArray)
 
 /// The character offset should be aware of unicode, otherwise, the common prefix can end up
 /// splitting a single character's bytes.
-size_t commonPrefix(wstring text1, wstring text2)
-{
+size_t commonPrefix(Str)(Str text1, Str text2)
+if (isSomeString!Str) {
     auto n = min(text1.length, text2.length);
     foreach (i; 0 .. n)
         if (text1[i] != text2[i])
@@ -294,8 +300,8 @@ size_t commonPrefix(wstring text1, wstring text2)
     return n;
 }
 
-size_t commonSuffix(wstring text1, wstring text2)
-{
+size_t commonSuffix(Str)(Str text1, Str text2)
+if (isSomeString!Str) {
     auto n = min(text1.length, text2.length);
     foreach (i; 1 .. n+1)
         if (text1[$-i] != text2[$-i])
@@ -310,7 +316,8 @@ size_t commonSuffix(wstring text1, wstring text2)
 * @return The number of characters common to the end of the first
 *     string and the start of the second string.
 */
-size_t commonOverlap(wstring text1, wstring text2) {
+size_t commonOverlap(Str)(Str text1, Str text2)
+if (isSomeString!Str) {
     // Cache the text lengths to prevent multiple calls.
     auto text1_length = text1.length;
     auto text2_length = text2.length;
@@ -335,7 +342,7 @@ size_t commonOverlap(wstring text1, wstring text2) {
     int best = 0;
     int length = 1;
     while (true) {
-        wstring pattern = text1[text_length - length .. $];
+        Str pattern = text1[text_length - length .. $];
         auto found = text2.indexOf(pattern);
         if (found == -1) {
             return best;
@@ -349,12 +356,12 @@ size_t commonOverlap(wstring text1, wstring text2) {
 }
 
 /**-
-* The data structure representing a diff is a List of Diff objects:
-* {Diff(Operation.DELETE, "Hello"), Diff(Operation.INSERT, "Goodbye"),
-*  Diff(Operation.EQUAL, " world.")}
+* The data structure representing a diff is a List of DiffT objects:
+* {DiffT(Operation.DELETE, "Hello"), DiffT(Operation.INSERT, "Goodbye"),
+*  DiffT(Operation.EQUAL, " world.")}
 * which means: delete "Hello", add "Goodbye" and keep " world."
 */
-enum Operation { 
+enum Operation {
     DELETE,
     INSERT,
     EQUAL
@@ -364,16 +371,12 @@ enum Operation {
 /**
 * Struct representing one diff operation.
 */
-struct Diff {
+struct DiffT(Str)
+if (isSomeString!Str) {
     Operation operation;
-    wstring text;
+    Str text;
 
-    this(Operation operation, string text)
-    {
-        this(operation, toUTF16(text));
-    }
-
-    this(Operation operation, wstring text)
+    this(Operation operation, Str text)
     {
         this.operation = operation;
         this.text = text;
@@ -391,10 +394,10 @@ struct Diff {
             case Operation.EQUAL:
                 op = "EQUAL"; break;
         }
-        return "Diff(" ~ op ~ ",\"" ~ toUTF8(text) ~ "\")";
+        return "DiffT!" ~ Str.stringof ~ "(" ~ op ~ ",\"" ~ toUTF8(text) ~ "\")";
     }
 
-    bool opEquals(const Diff other) const
+    bool opEquals(const DiffT other) const
     {
         return operation == other.operation && text == other.text;
     }
@@ -408,13 +411,9 @@ struct Diff {
  * Most of the time checklines is wanted, so default to true.
  * @param text1 Old string to be diffed.
  * @param text2 New string to be diffed.
- * @return List of Diff objects.
+ * @return List of DiffT objects.
  */
-Diff[] diff_main(string text1, string text2) {
-    return diff_main(toUTF16(text1), toUTF16(text2));
-}
-
-Diff[] diff_main(wstring text1, wstring text2)
+DiffT!(Str)[] diff_main(Str)(Str text1, Str text2)
 {
     return diff_main(text1, text2, true);
 }
@@ -426,13 +425,9 @@ Diff[] diff_main(wstring text1, wstring text2)
  * @param checklines Speedup flag.  If false, then don't run a
  *     line-level diff first to identify the changed areas.
  *     If true, then run a faster slightly less optimal diff.
- * @return List of Diff objects.
+ * @return List of DiffT objects.
  */
-Diff[] diff_main(string text1, string text2, bool checklines) {
-    return diff_main(toUTF16(text1), toUTF16(text2), checklines);
-}
-
-Diff[] diff_main(wstring text1, wstring text2, bool checklines)
+DiffT!(Str)[] diff_main(Str)(Str text1, Str text2, bool checklines)
 {
     // Set a deadline by which time the diff must be complete.
     SysTime deadline;
@@ -453,19 +448,15 @@ Diff[] diff_main(wstring text1, wstring text2, bool checklines)
  *     line-level diff first to identify the changed areas.
  *     If true, then run a faster slightly less optimal diff.
  * @param deadline Time when the diff should be complete by.  Used
- *     internally for recursive calls.  Users should set DiffTimeout
+ *     internally for recursive calls.  Users should set DiffTTimeout
  *     instead.
- * @return List of Diff objects.
+ * @return List of DiffT objects.
  */
-Diff[] diff_main(string text1, string text2, bool checklines, SysTime deadline) {
-    return diff_main(toUTF16(text1), toUTF16(text2), checklines, deadline);
-}
-
-Diff[] diff_main(wstring text1, wstring text2, bool checklines, SysTime deadline)
+DiffT!(Str)[] diff_main(Str)(Str text1, Str text2, bool checklines, SysTime deadline)
 {
-    Diff[] diffs;
+    DiffT!(Str)[] diffs;
     if( text1 == text2 ){
-        if( text1.length != 0 ) diffs ~= Diff(Operation.EQUAL, text1);
+        if( text1.length != 0 ) diffs ~= DiffT!Str(Operation.EQUAL, text1);
         return diffs;
     }
 
@@ -480,14 +471,14 @@ Diff[] diff_main(wstring text1, wstring text2, bool checklines, SysTime deadline
     text2 = text2[0 .. $ - pos];
 
     // Compute the diff on the middle block.
-    diffs = computeDiffs(text1, text2, checklines, deadline);
+    diffs = computeDiffTs(text1, text2, checklines, deadline);
 
       // Restore the prefix and suffix.
     if( prefix.length != 0 ) {
-        diffs.insert(0, [Diff(Operation.EQUAL, prefix)]);
+        diffs.insert(0, [DiffT!Str(Operation.EQUAL, prefix)]);
     }
     if( suffix.length != 0 ) {
-        diffs ~= Diff(Operation.EQUAL, suffix);
+        diffs ~= DiffT!Str(Operation.EQUAL, suffix);
     }
 
     cleanupMerge(diffs);
@@ -495,21 +486,23 @@ Diff[] diff_main(wstring text1, wstring text2, bool checklines, SysTime deadline
 }
 
 
+alias HalfMatch = HalfMatchT!string;
 
-struct HalfMatch {
-    wstring prefix1;
-    wstring suffix1;
-    wstring suffix2;
-    wstring prefix2;
-    wstring commonMiddle;
+struct HalfMatchT(Str) {
+    Str prefix1;
+    Str suffix1;
+    Str suffix2;
+    Str prefix2;
+    Str commonMiddle;
 
-    bool opEquals()(auto ref const HalfMatch other) const {
+    bool opEquals()(auto ref const HalfMatchT!Str other) const {
         return prefix1 == other.prefix1 &&
                suffix1 == other.suffix1 &&
                prefix2 == other.prefix2 &&
                suffix2 == other.suffix2;
     }
 }
+
 /*
  * Do the two texts share a Substring which is at least half the length of
  * the longer text?
@@ -520,20 +513,20 @@ struct HalfMatch {
  *     suffix of text1, the prefix of text2, the suffix of text2 and the
  *     common middle.  Or null if there was no match.
  */
-bool halfMatch(wstring text1, wstring text2, out HalfMatch halfmatch){
+bool halfMatch(Str)(Str text1, Str text2, out HalfMatchT!Str halfmatch){
     if (diffTimeout <= 0.seconds) {
         // Don't risk returning a non-optimal diff if we have unlimited time.
         return false;
     }
-    wstring longtext = text1.length > text2.length ? text1 : text2;
-    wstring shorttext = text1.length > text2.length ? text2 : text1;
+    Str longtext = text1.length > text2.length ? text1 : text2;
+    Str shorttext = text1.length > text2.length ? text2 : text1;
     if( longtext.length < 4 || shorttext.length * 2 < longtext.length ) return false; //pointless
-    HalfMatch hm1;
-    HalfMatch hm2;
+    HalfMatchT!Str hm1;
+    HalfMatchT!Str hm2;
     auto is_hm1 = halfMatchI(longtext, shorttext, (longtext.length + 3) / 4, hm1);
     auto is_hm2 = halfMatchI(longtext, shorttext, (longtext.length + 1) / 2, hm2);
-    HalfMatch hm;
-    if( !is_hm1 && !is_hm2 ){ 
+    HalfMatchT!Str hm;
+    if( !is_hm1 && !is_hm2 ){
         return false;
     } else if( !is_hm2  ){
         hm = hm1;
@@ -543,7 +536,7 @@ bool halfMatch(wstring text1, wstring text2, out HalfMatch halfmatch){
         hm = hm1.commonMiddle.length > hm2.commonMiddle.length ? hm1 : hm2;
     }
 
-    if( text1.length > text2.length ) { 
+    if( text1.length > text2.length ) {
         halfmatch = hm;
         return true;
     }
@@ -556,14 +549,14 @@ bool halfMatch(wstring text1, wstring text2, out HalfMatch halfmatch){
 }
 
 
-bool halfMatchI(wstring longtext, wstring shorttext, sizediff_t i, out HalfMatch hm){
+bool halfMatchI(Str)(Str longtext, Str shorttext, sizediff_t i, out HalfMatchT!Str hm){
     auto seed = longtext.substr(i, longtext.length / 4);
     sizediff_t j = -1;
-    wstring best_common;
-    wstring best_longtext_a;
-    wstring best_longtext_b;
-    wstring best_shorttext_a;
-    wstring best_shorttext_b;
+    Str best_common;
+    Str best_longtext_a;
+    Str best_longtext_b;
+    Str best_shorttext_a;
+    Str best_shorttext_b;
     while( j < cast(sizediff_t)shorttext.length && ( j = shorttext.indexOfAlt(seed, j + 1)) != -1 ){
         auto prefixLen = commonPrefix(longtext[i .. $], shorttext[j .. $]);
         auto suffixLen = commonSuffix(longtext[0 .. i], shorttext[0 .. j]);
@@ -597,18 +590,18 @@ bool halfMatchI(wstring longtext, wstring shorttext, sizediff_t i, out HalfMatch
  *     line-level diff first to identify the changed areas.
  *     If true, then run a faster slightly less optimal diff.
  * @param deadline Time when the diff should be complete by.
- * @return List of Diff objects.
+ * @return List of DiffT objects.
  */
-Diff[] computeDiffs(wstring text1, wstring text2, bool checklines, SysTime deadline)
+DiffT!(Str)[] computeDiffTs(Str)(Str text1, Str text2, bool checklines, SysTime deadline)
 {
-    Diff[] diffs;
+    DiffT!(Str)[] diffs;
 
     if( text1.length == 0 ){
-        diffs ~= Diff(Operation.INSERT, text2);
+        diffs ~= DiffT!Str(Operation.INSERT, text2);
         return diffs;
     }
     if( text2.length == 0 ){
-        diffs ~= Diff(Operation.DELETE, text1);
+        diffs ~= DiffT!Str(Operation.DELETE, text1);
         return diffs;
     }
 
@@ -617,25 +610,25 @@ Diff[] computeDiffs(wstring text1, wstring text2, bool checklines, SysTime deadl
     auto i = longtext.indexOf(shorttext);
     if( i != -1 ){
         Operation op = (text1.length > text2.length) ? Operation.DELETE : Operation.INSERT;
-        diffs ~= Diff(op, longtext[0 .. i]);
-        diffs ~= Diff(Operation.EQUAL, shorttext);
-        diffs ~= Diff(op, longtext[i + shorttext.length .. $]);
+        diffs ~= DiffT!Str(op, longtext[0 .. i]);
+        diffs ~= DiffT!Str(Operation.EQUAL, shorttext);
+        diffs ~= DiffT!Str(op, longtext[i + shorttext.length .. $]);
         return diffs;
     }
 
     if( shorttext.length == 1 ){
-        diffs ~= Diff(Operation.DELETE, text1);
-        diffs ~= Diff(Operation.INSERT, text2);
+        diffs ~= DiffT!Str(Operation.DELETE, text1);
+        diffs ~= DiffT!Str(Operation.INSERT, text2);
         return diffs;
     }
-    HalfMatch hm;
+    HalfMatchT!Str hm;
     auto is_hm = halfMatch(text1, text2, hm);
     if( is_hm ){
         auto diffs_a = diff_main(hm.prefix1, hm.prefix2, checklines, deadline);
         auto diffs_b = diff_main(hm.suffix1, hm.suffix2, checklines, deadline);
 
         diffs = diffs_a;
-        diffs ~= Diff(Operation.EQUAL, hm.commonMiddle);
+        diffs ~= DiffT!Str(Operation.EQUAL, hm.commonMiddle);
         diffs ~= diffs_b;
         return diffs;
     }
@@ -647,11 +640,7 @@ Diff[] computeDiffs(wstring text1, wstring text2, bool checklines, SysTime deadl
     return bisect(text1, text2, deadline);
 }
 
-Diff[] diff_lineMode(string text1, string text2, SysTime deadline) {
-    return diff_lineMode(toUTF16(text1), toUTF16(text2), deadline);
-}
-
-Diff[] diff_lineMode(wstring text1, wstring text2, SysTime deadline)
+DiffT!(Str)[] diff_lineMode(Str)(Str text1, Str text2, SysTime deadline)
 {
     auto b = linesToChars(text1, text2);
 
@@ -660,12 +649,12 @@ Diff[] diff_lineMode(wstring text1, wstring text2, SysTime deadline)
     charsToLines(diffs, b.uniqueStrings);
     cleanupSemantic(diffs);
 
-    diffs ~= Diff(Operation.EQUAL, "");
+    diffs ~= DiffT!Str(Operation.EQUAL, "");
     auto pointer = 0;
     auto count_delete = 0;
     auto count_insert = 0;
-    wstring text_delete;
-    wstring text_insert;
+    Str text_delete;
+    Str text_insert;
     while( pointer < diffs.length ){
         final switch( diffs[pointer].operation ) {
             case Operation.INSERT:
@@ -700,11 +689,7 @@ Diff[] diff_lineMode(wstring text1, wstring text2, SysTime deadline)
     return diffs;
 }
 
-Diff[] bisect(string text1, string text2, SysTime deadline) {
-    return bisect(toUTF16(text1), toUTF16(text2), deadline);
-}
-
-Diff[] bisect(wstring text1, wstring text2, SysTime deadline)
+DiffT!(Str)[] bisect(Str)(Str text1, Str text2, SysTime deadline)
 {
     auto text1_len = text1.length;
     auto text2_len = text2.length;
@@ -755,7 +740,7 @@ Diff[] bisect(wstring text1, wstring text2, SysTime deadline)
                     auto x2 = text1_len - v2[k2_offset];
                     if( x1 >= x2 ) return bisectSplit(text1, text2, x1, y1, deadline);
                 }
-            } 
+            }
         }
         for( auto k2 = -d + k2start; k2 <= d - k2end; k2 += 2) {
             auto k2_offset = v_offset + k2;
@@ -794,32 +779,32 @@ Diff[] bisect(wstring text1, wstring text2, SysTime deadline)
             }
         }
     }
-    Diff[] diffs;
-    diffs ~= Diff(Operation.DELETE, text1);
-    diffs ~= Diff(Operation.INSERT, text2);
+    DiffT!(Str)[] diffs;
+    diffs ~= DiffT!Str(Operation.DELETE, text1);
+    diffs ~= DiffT!Str(Operation.INSERT, text2);
     return diffs;
 }
 
 
-Diff[] bisectSplit(wstring text1, wstring text2, sizediff_t x, sizediff_t y, SysTime deadline)
+DiffT!(Str)[] bisectSplit(Str)(Str text1, Str text2, sizediff_t x, sizediff_t y, SysTime deadline)
 {
     auto text1a = text1[0 .. x];
     auto text2a = text2[0 .. y];
     auto text1b = text1[x .. $];
     auto text2b = text2[y .. $];
 
-    Diff[] diffs = diff_main(text1a, text2a, false, deadline);
-    Diff[] diffsb = diff_main(text1b, text2b, false, deadline);
+    DiffT!(Str)[] diffs = diff_main(text1a, text2a, false, deadline);
+    DiffT!(Str)[] diffsb = diff_main(text1b, text2b, false, deadline);
     diffs ~= diffsb;
     return diffs;
 }
 
-void cleanupSemantic(ref Diff[] diffs) 
+void cleanupSemantic(Str)(ref DiffT!(Str)[] diffs)
 {
     bool changes = false;
     size_t[] equalities;
 
-    wstring last_equality = null;
+    Str last_equality = null;
     size_t pointer = 0;
     size_t length_insertions1 = 0;
     size_t length_deletions1 = 0;
@@ -841,13 +826,13 @@ void cleanupSemantic(ref Diff[] diffs)
                 length_deletions2 += diffs[pointer].text.length;
             }
 
-            if( last_equality !is null && 
+            if( last_equality !is null &&
                 (last_equality.length <= max(length_insertions1, length_deletions1))
                 && (last_equality.length <= max(length_insertions2, length_deletions2)))
             {
                 // Duplicate record.
-                diffs.insert(equalities[$-1], [Diff(Operation.DELETE, last_equality)]);
-                diffs[equalities[$-1]+1] = Diff(Operation.INSERT, diffs[equalities[$-1]+1].text);
+                diffs.insert(equalities[$-1], [DiffT!Str(Operation.DELETE, last_equality)]);
+                diffs[equalities[$-1]+1] = DiffT!Str(Operation.INSERT, diffs[equalities[$-1]+1].text);
 
                 // Throw away the equality we just deleted.
                 equalities.length--;
@@ -890,11 +875,11 @@ void cleanupSemantic(ref Diff[] diffs)
             auto overlap_len1 = commonOverlap(deletion, insertion);
             auto overlap_len2 = commonOverlap(insertion, deletion);
             if( overlap_len1 >= overlap_len2 ){
-                if( overlap_len1 * 2 >= deletion.length || 
+                if( overlap_len1 * 2 >= deletion.length ||
                     overlap_len1 * 2 >= insertion.length) {
                     //Overlap found.
                     //Insert an equality and trim the surrounding edits.
-                    diffs.insert(pointer, [Diff(Operation.EQUAL, insertion[0 .. overlap_len1])]);
+                    diffs.insert(pointer, [DiffT!Str(Operation.EQUAL, insertion[0 .. overlap_len1])]);
                     diffs[pointer - 1].text = deletion[0 .. $ - overlap_len1];
                     diffs[pointer + 1].text = insertion[overlap_len1 .. $];
                     pointer++;
@@ -902,7 +887,7 @@ void cleanupSemantic(ref Diff[] diffs)
             } else {
                 if( overlap_len2 * 2 >= deletion.length ||
                     overlap_len2 * 2 >= insertion.length) {
-                    diffs.insert(pointer, [Diff(Operation.EQUAL, deletion[0 .. overlap_len2])]);
+                    diffs.insert(pointer, [DiffT!Str(Operation.EQUAL, deletion[0 .. overlap_len2])]);
 
                     diffs[pointer - 1].operation = Operation.INSERT;
                     diffs[pointer - 1].text = insertion[0 .. $ - overlap_len2];
@@ -921,9 +906,9 @@ void cleanupSemantic(ref Diff[] diffs)
  * Look for single edits surrounded on both sides by equalities
  * which can be shifted sideways to align the edit to a word boundary.
  * e.g: The c<ins>at c</ins>ame. -> The <ins>cat </ins>came.
- * @param diffs List of Diff objects.
+ * @param diffs List of DiffT objects.
  */
-void cleanupSemanticLossless(ref Diff[] diffs)
+void cleanupSemanticLossless(Str)(ref DiffT!(Str)[] diffs)
 {
     auto pointer = 1;
     // Intentionally ignore the first and last element (don't need checking).
@@ -992,15 +977,15 @@ void cleanupSemanticLossless(ref Diff[] diffs)
 /**
  * Reorder and merge like edit sections.  Merge equalities.
  * Any edit section can move as sizediff_t as it doesn't cross an equality.
- * @param diffs List of Diff objects.
+ * @param diffs List of DiffT objects.
  */
-void cleanupMerge(ref Diff[] diffs) {
-    diffs ~= Diff(Operation.EQUAL, "");
+void cleanupMerge(Str)(ref DiffT!(Str)[] diffs) {
+    diffs ~= DiffT!(Str)(Operation.EQUAL, "");
     size_t pointer = 0;
     size_t count_delete = 0;
     size_t count_insert = 0;
-    wstring text_delete;
-    wstring text_insert;
+    Str text_delete;
+    Str text_insert;
     while(pointer < diffs.length) {
         final switch(diffs[pointer].operation){
             case Operation.INSERT:
@@ -1026,7 +1011,7 @@ void cleanupMerge(ref Diff[] diffs) {
                                 diffs[pointer - count_delete - count_insert - 1].text
                                     ~= text_insert[0 .. commonlength];
                             } else {
-                                diffs.insert(0, [Diff(Operation.EQUAL, text_insert[0 .. commonlength])]);
+                                diffs.insert(0, [DiffT!Str(Operation.EQUAL, text_insert[0 .. commonlength])]);
                                 pointer++;
                             }
                             text_insert = text_insert[commonlength .. $];
@@ -1041,12 +1026,20 @@ void cleanupMerge(ref Diff[] diffs) {
                     }
                     // Delete the offending records and add the merged ones.
                     if (count_delete == 0) {
-                        diffs.splice(pointer - count_insert, count_delete + count_insert, [Diff(Operation.INSERT, text_insert)]);
+                        diffs.splice(
+                                pointer - count_insert,
+                                count_delete + count_insert,
+                                [DiffT!Str(Operation.INSERT, text_insert)]);
                     } else if (count_insert == 0) {
-
-                        diffs.splice(pointer - count_delete, count_delete + count_insert, [Diff(Operation.DELETE, text_delete)]);
+                        diffs.splice(
+                                pointer - count_delete,
+                                count_delete + count_insert,
+                                [DiffT!Str(Operation.DELETE, text_delete)]);
                     } else {
-                        diffs.splice(pointer - count_delete - count_insert, count_delete + count_insert, [Diff(Operation.DELETE, text_delete), Diff(Operation.INSERT, text_insert)]);
+                        diffs.splice(
+                                pointer - count_delete - count_insert,
+                                count_delete + count_insert,
+                                [DiffT!Str(Operation.DELETE, text_delete), DiffT!Str(Operation.INSERT, text_insert)]);
                     }
                     pointer = pointer - count_delete - count_insert +
                             (count_delete != 0 ? 1 : 0) + (count_insert != 0 ? 1 : 0) + 1;
@@ -1066,11 +1059,11 @@ void cleanupMerge(ref Diff[] diffs) {
     if( diffs[$-1].text.length == 0){
         diffs.length--;
     }
-    
+
     bool changes = false;
     pointer = 1;
     while( pointer + 1 < diffs.length ) {
-        if( diffs[pointer - 1].operation == Operation.EQUAL && 
+        if( diffs[pointer - 1].operation == Operation.EQUAL &&
             diffs[pointer + 1].operation == Operation.EQUAL)
         {
             if( diffs[pointer].text.endsWith(diffs[pointer - 1].text)) {
@@ -1103,7 +1096,7 @@ void cleanupMerge(ref Diff[] diffs) {
  * @param two Second string.
  * @return The score.
  */
-int cleanupSemanticScore(wstring one, wstring two)
+int cleanupSemanticScore(Str)(Str one, Str two)
 {
     if( one.length == 0 || two.length == 0) return 6; //Edges are the best
     auto char1 = one[$-1];
@@ -1115,8 +1108,8 @@ int cleanupSemanticScore(wstring one, wstring two)
     auto whitespace2 = nonAlphaNumeric2 && isWhite(char2);
     auto lineBreak1 = whitespace1 && isControl(char1);
     auto lineBreak2 = whitespace2 && isControl(char2);
-    auto blankLine1 = lineBreak1 &&  match(one, `\n\r?\n\Z`w);
-    auto blankLine2 = lineBreak2 &&  match(two, `\A\r?\n\r?\n`w);
+    auto blankLine1 = lineBreak1 &&  match(one, `\n\r?\n\Z`.to!Str);
+    auto blankLine2 = lineBreak2 &&  match(two, `\A\r?\n\r?\n`.to!Str);
 
     if (blankLine1 || blankLine2) return 5;
     else if (lineBreak1 || lineBreak2) return 4;
@@ -1131,12 +1124,12 @@ int cleanupSemanticScore(wstring one, wstring two)
 /**
  * Reduce the number of edits by eliminating operationally trivial
  * equalities.
- * @param diffs List of Diff objects.
+ * @param diffs List of DiffT objects.
  */
-void cleanupEfficiency(ref Diff[] diffs) {
+void cleanupEfficiency(Str)(ref DiffT!(Str)[] diffs) {
     bool changes = false;
     size_t[] equalities;
-    wstring lastequality;
+    Str lastequality;
     size_t pointer = 0;
     auto pre_ins = false;
     auto pre_del = false;
@@ -1171,7 +1164,7 @@ void cleanupEfficiency(ref Diff[] diffs) {
                     )
                 )
             {
-                diffs.insert(equalities[$-1], [Diff(Operation.DELETE, lastequality)]);
+                diffs.insert(equalities[$-1], [DiffT!Str(Operation.DELETE, lastequality)]);
                 diffs[equalities[$-1] + 1].operation = Operation.INSERT;
                 equalities.length--;
                 equalities.assumeSafeAppend;
@@ -1206,16 +1199,16 @@ void cleanupEfficiency(ref Diff[] diffs) {
  * loc is a location in text1, comAdde and return the equivalent location in
  * text2.
  * e.g. "The cat" vs "The big cat", 1->1, 5->8
- * @param diffs List of Diff objects.
+ * @param diffs List of DiffT objects.
  * @param loc Location within text1.
  * @return Location within text2.
  */
-sizediff_t xIndex(Diff[] diffs, sizediff_t loc){
+sizediff_t xIndex(Str)(DiffT!(Str)[] diffs, sizediff_t loc) {
     auto chars1 = 0;
     auto chars2 = 0;
     auto last_chars1 = 0;
     auto last_chars2 = 0;
-    Diff lastDiff;
+    DiffT!Str lastDiffT;
     foreach ( diff; diffs) {
         if (diff.operation != Operation.INSERT) {
             // Equality or deletion.
@@ -1227,13 +1220,13 @@ sizediff_t xIndex(Diff[] diffs, sizediff_t loc){
         }
         if (chars1 > loc) {
             // Overshot the location.
-            lastDiff = diff;
+            lastDiffT = diff;
             break;
         }
         last_chars1 = chars1;
         last_chars2 = chars2;
     }
-    if (lastDiff.operation == Operation.DELETE) {
+    if (lastDiffT.operation == Operation.DELETE) {
         // The location was deleted.
         return last_chars2;
     }

--- a/source/ddmp/diff.d
+++ b/source/ddmp/diff.d
@@ -250,7 +250,7 @@ if (isSomeString!Str) {
     static if (is(ElementEncodingType!Str : char)) {
       size_t lineLimit = 0x80;
     } else {
-      size_t lineLimit = 0x0D800;
+      size_t lineLimit = 0xD800;
     }
     enforce(lines.length < lineLimit, "Algorithm unique line limit exceeded for "
         ~ Str.stringof ~ ". string may use 127 lines, wstring/dstring may use 55295 lines.");
@@ -1002,7 +1002,7 @@ void cleanupMerge(Str)(ref DiffT!(Str)[] diffs) {
                 // Upon reaching an equality, check for prior redundancies.
                 if (count_delete + count_insert > 1) {
                     if (count_delete != 0 && count_insert != 0) {
-                        // Factor out any common prefixies.
+                        // Factor out any common prefixes.
                         if (auto commonlength = commonPrefix(text_insert, text_delete)) {
                             if (pointer > count_delete + count_insert &&
                                 diffs[pointer - count_delete - count_insert - 1].operation
@@ -1017,7 +1017,7 @@ void cleanupMerge(Str)(ref DiffT!(Str)[] diffs) {
                             text_insert = text_insert[commonlength .. $];
                             text_delete = text_delete[commonlength .. $];
                         }
-                        // Factor out any common suffixies.
+                        // Factor out any common suffixes.
                         if (auto commonlength = commonSuffix(text_insert, text_delete)) {
                             diffs[pointer].text = text_insert[$ - commonlength .. $] ~ diffs[pointer].text;
                             text_insert = text_insert[0 .. $ - commonlength];

--- a/source/ddmp/match.d
+++ b/source/ddmp/match.d
@@ -26,11 +26,12 @@ import std.algorithm : min, max;
 import std.array;
 import std.math : abs;
 import std.string;
+import std.utf : toUTF16, toUTF8;
 
 import ddmp.util;
 
 float MATCH_THRESHOLD = 0.5f;
-int MATCH_DISTANCE = 1000; 
+int MATCH_DISTANCE = 1000;
 
 /**
  * Locate the best instance of 'pattern' in 'text' near 'loc'.
@@ -40,7 +41,11 @@ int MATCH_DISTANCE = 1000;
  * @param loc The location to search around.
  * @return Best match index or -1.
  */
-sizediff_t match_main(string text, string pattern, sizediff_t loc)
+sizediff_t match_main(string text, string pattern, sizediff_t loc) {
+  return match_main(toUTF16(text), toUTF16(pattern), loc);
+}
+
+sizediff_t match_main(wstring text, wstring pattern, sizediff_t loc)
 {
 	loc = max(0, min(loc, text.length));
 	if( text == pattern ){
@@ -63,12 +68,12 @@ sizediff_t match_main(string text, string pattern, sizediff_t loc)
  * @param loc The location to search around.
  * @return Best match index or -1.
  */
-sizediff_t bitap(string text, string pattern, sizediff_t loc)
+sizediff_t bitap(wstring text, wstring pattern, sizediff_t loc)
 {
 	// bits need to fit into the positive part of an int
 	assert(pattern.length <= 31);
 
-	int[char] s = initAlphabet(pattern);
+	int[wchar] s = initAlphabet(pattern);
 	double score_threshold = MATCH_THRESHOLD;
 	auto best_loc = text.indexOfAlt(pattern, loc);
 	if( best_loc != -1 ){
@@ -149,7 +154,7 @@ sizediff_t bitap(string text, string pattern, sizediff_t loc)
  * @param pattern Pattern being sought.
  * @return Overall score for match (0.0 = good, 1.0 = bad).
  */
-double bitapScore(sizediff_t e, sizediff_t x, sizediff_t loc, string pattern) 
+double bitapScore(sizediff_t e, sizediff_t x, sizediff_t loc, wstring pattern)
 {
 	auto accuracy = cast(float)e / pattern.length;
 	sizediff_t proximity = abs(loc - x);
@@ -164,15 +169,15 @@ double bitapScore(sizediff_t e, sizediff_t x, sizediff_t loc, string pattern)
  * @param pattern The text to encode.
  * @return Hash of character locations.
  */
-int[char] initAlphabet(string pattern)
+int[wchar] initAlphabet(wstring pattern)
 {
-	int[char] s;
+	int[wchar] s;
 	foreach( c ; pattern ){
 		if( c !in s )s[c] = 0;
 	}
 	foreach( i, c; pattern ){
 		auto value = s[c] | (1 << (pattern.length - i - 1));
-		s[c] = value; 
+		s[c] = value;
 	}
 	return s;
 }

--- a/source/ddmp/match.d
+++ b/source/ddmp/match.d
@@ -25,8 +25,10 @@ module ddmp.match;
 import std.algorithm : min, max;
 import std.array;
 import std.math : abs;
+import std.range : ElementEncodingType;
 import std.string;
 import std.utf : toUTF16, toUTF8;
+import std.traits : isSomeString, Unqual;
 
 import ddmp.util;
 
@@ -41,12 +43,8 @@ int MATCH_DISTANCE = 1000;
  * @param loc The location to search around.
  * @return Best match index or -1.
  */
-sizediff_t match_main(string text, string pattern, sizediff_t loc) {
-  return match_main(toUTF16(text), toUTF16(pattern), loc);
-}
-
-sizediff_t match_main(wstring text, wstring pattern, sizediff_t loc)
-{
+sizediff_t match_main(Str)(Str text, Str pattern, sizediff_t loc)
+if (isSomeString!Str) {
 	loc = max(0, min(loc, text.length));
 	if( text == pattern ){
 		return 0; // Shortcut (potentially not guaranteed by the algorithm)
@@ -68,12 +66,12 @@ sizediff_t match_main(wstring text, wstring pattern, sizediff_t loc)
  * @param loc The location to search around.
  * @return Best match index or -1.
  */
-sizediff_t bitap(wstring text, wstring pattern, sizediff_t loc)
-{
+sizediff_t bitap(Str)(Str text, Str pattern, sizediff_t loc)
+if (isSomeString!Str) {
 	// bits need to fit into the positive part of an int
 	assert(pattern.length <= 31);
 
-	int[wchar] s = initAlphabet(pattern);
+	int[Unqual!(ElementEncodingType!Str)] s = initAlphabet(pattern);
 	double score_threshold = MATCH_THRESHOLD;
 	auto best_loc = text.indexOfAlt(pattern, loc);
 	if( best_loc != -1 ){
@@ -82,7 +80,7 @@ sizediff_t bitap(wstring text, wstring pattern, sizediff_t loc)
 		best_loc = text[0..min(loc + pattern.length, text.length)].lastIndexOf(pattern);
 		if( best_loc != -1){
 			score_threshold = min(bitapScore(0, best_loc, loc, pattern), score_threshold);
-		}		
+		}
 	}
 
 	sizediff_t matchmask = 1 << (pattern.length - 1);
@@ -110,7 +108,7 @@ sizediff_t bitap(wstring text, wstring pattern, sizediff_t loc)
         bin_max = bin_mid;
         sizediff_t start = max(1, loc - bin_mid + 1);
         sizediff_t finish = min(loc + bin_mid, text.length) + pattern.length;
-		
+
 		sizediff_t[] rd = new sizediff_t[finish + 2];
 		rd[finish + 1] = (1 << d) - 1;
 		for( sizediff_t j = finish; j >= start; j--) {
@@ -154,8 +152,8 @@ sizediff_t bitap(wstring text, wstring pattern, sizediff_t loc)
  * @param pattern Pattern being sought.
  * @return Overall score for match (0.0 = good, 1.0 = bad).
  */
-double bitapScore(sizediff_t e, sizediff_t x, sizediff_t loc, wstring pattern)
-{
+double bitapScore(Str)(sizediff_t e, sizediff_t x, sizediff_t loc, Str pattern)
+if (isSomeString!Str) {
 	auto accuracy = cast(float)e / pattern.length;
 	sizediff_t proximity = abs(loc - x);
 	if( MATCH_DISTANCE == 0 ){
@@ -169,9 +167,9 @@ double bitapScore(sizediff_t e, sizediff_t x, sizediff_t loc, wstring pattern)
  * @param pattern The text to encode.
  * @return Hash of character locations.
  */
-int[wchar] initAlphabet(wstring pattern)
-{
-	int[wchar] s;
+int[Unqual!(ElementEncodingType!Str)] initAlphabet(Str)(Str pattern)
+if (isSomeString!Str) {
+	int[Unqual!(ElementEncodingType!Str)] s;
 	foreach( c ; pattern ){
 		if( c !in s )s[c] = 0;
 	}

--- a/source/ddmp/match.d
+++ b/source/ddmp/match.d
@@ -29,6 +29,7 @@ import std.range : ElementEncodingType;
 import std.string;
 import std.utf : toUTF16, toUTF8;
 import std.traits : isSomeString, Unqual;
+import std.exception : enforce;
 
 import ddmp.util;
 
@@ -69,7 +70,7 @@ if (isSomeString!Str) {
 sizediff_t bitap(Str)(Str text, Str pattern, sizediff_t loc)
 if (isSomeString!Str) {
 	// bits need to fit into the positive part of an int
-	assert(pattern.length <= 31);
+	enforce(pattern.length <= 32, "Pattern too long for this application.");
 
 	int[Unqual!(ElementEncodingType!Str)] s = initAlphabet(pattern);
 	double score_threshold = MATCH_THRESHOLD;

--- a/source/ddmp/patch.d
+++ b/source/ddmp/patch.d
@@ -25,8 +25,10 @@ import std.algorithm : min, max;
 import std.array;
 import std.conv;
 import std.exception : enforce;
+import std.range : ElementEncodingType;
 import std.string:lastIndexOf;
 import std.utf : toUTF16, toUTF8;
+import std.traits : isSomeString, Unqual;
 
 import ddmp.diff;
 import ddmp.match;
@@ -36,8 +38,10 @@ int MATCH_MAXBITS = 32;
 int PATCH_MARGIN = 4;
 float PATCH_DELETE_THRESHOLD = 0.5f;
 
-struct Patch {
-    Diff[] diffs;
+alias Patch = PatchT!string;
+
+struct PatchT(Str) {
+    DiffT!(Str)[] diffs;
     sizediff_t start1;
     sizediff_t start2;
     sizediff_t length1;
@@ -97,7 +101,7 @@ struct Patch {
  * @param patch The patch to grow.
  * @param text Source text.
  */
-void addContext(ref Patch patch, wstring text)
+void addContext(Str)(ref PatchT!Str patch, Str text)
 {
 	if( text.length == 0 ) return;
 
@@ -109,7 +113,7 @@ void addContext(ref Patch patch, wstring text)
 	while( text.indexOfAlt(pattern) != text.lastIndexOf(pattern)
 		  && pattern.length < MATCH_MAXBITS - PATCH_MARGIN - PATCH_MARGIN ){
 		padding += PATCH_MARGIN;
-		pattern = text[max(0, patch.start2 - padding)..min(text.length, patch .start2 + patch.length1 + padding)];		
+		pattern = text[max(0, patch.start2 - padding)..min(text.length, patch .start2 + patch.length1 + padding)];
 	}
 	// Add one chunk for good luck.
 	padding += PATCH_MARGIN;
@@ -117,13 +121,13 @@ void addContext(ref Patch patch, wstring text)
 	// Add the prefix.
 	auto prefix = text[max(0, patch.start2 - padding)..patch.start2];
 	if( prefix.length != 0 ){
-		patch.diffs.insert(0, [Diff(Operation.EQUAL, prefix)]);
+		patch.diffs.insert(0, [DiffT!Str(Operation.EQUAL, prefix)]);
 	}
 
 	// Add the suffix.
 	auto suffix = text[patch.start2 + patch.length1..min(text.length, patch.start2 + patch.length1 + padding)];
 	if( suffix.length != 0 ){
-		patch.diffs ~= Diff(Operation.EQUAL, suffix);
+		patch.diffs ~= DiffT!Str(Operation.EQUAL, suffix);
 	}
 
 	// Roll back the start points.
@@ -139,9 +143,9 @@ void addContext(ref Patch patch, wstring text)
 * A set of diffs will be computed.
 * @param text1 Old text.
 * @param text2 New text.
-* @return List of Patch objects.
+* @return List of PatchT objects.
 */
-Patch[] patch_make(string text1, string text2) {
+PatchT!(Str)[] patch_make(Str)(Str text1, Str text2) {
 	// No diffs provided, comAdde our own.
 	auto diffs = diff_main(text1, text2, true);
 	if (diffs.length > 2) {
@@ -155,10 +159,11 @@ Patch[] patch_make(string text1, string text2) {
 /**
  * Compute a list of patches to turn text1 into text2.
  * text1 will be derived from the provided diffs.
- * @param diffs Array of Diff objects for text1 to text2.
- * @return List of Patch objects.
+ * @param diffs Array of DiffT objects for text1 to text2.
+ * @return List of PatchT objects.
  */
-Patch[] patch_make(Diff[] diffs) {
+PatchT!(Str)[] patch_make(Str)(DiffT!(Str)[] diffs)
+if (isSomeString!Str) {
   // Check for null inputs not needed since null can't be passed in C#.
   // No origin string provided, comAdde our own.
   auto text1 = diff_text1(diffs);
@@ -170,19 +175,15 @@ Patch[] patch_make(Diff[] diffs) {
  * Compute a list of patches to turn text1 into text2.
  * text2 is not provided, diffs are the delta between text1 and text2.
  * @param text1 Old text.
- * @param diffs Array of Diff objects for text1 to text2.
- * @return List of Patch objects.
+ * @param diffs Array of DiffT objects for text1 to text2.
+ * @return List of PatchT objects.
  */
-Patch[] patch_make(string text1, Diff[] diffs) {
-  return patch_make(toUTF16(text1), diffs);
-}
-
-Patch[] patch_make(wstring text1, Diff[] diffs)
+PatchT!(Str)[] patch_make(Str)(Str text1, DiffT!(Str)[] diffs)
 {
-	Patch[] patches;
+	PatchT!(Str)[] patches;
 	if( diffs.length == 0 ) return patches;
 
-	Patch patch;
+	PatchT!Str patch;
 	auto char_count1 = 0;  // Number of characters into the text1 string.
 	auto char_count2 = 0;  // Number of characters into the text2 string.
 	// Start with text1 (prepatch_text) and apply the diffs until we arrive at
@@ -220,7 +221,7 @@ Patch[] patch_make(wstring text1, Diff[] diffs)
 					if( patch.diffs.length != 0 ){
 						addContext(patch, prepatch_text);
 						patches ~= patch;
-						patch = Patch();
+						patch = PatchT!Str();
 						prepatch_text = postpatch_text;
 						char_count1 = char_count2;
 					}
@@ -245,26 +246,28 @@ Patch[] patch_make(wstring text1, Diff[] diffs)
 }
 
 
+alias PatchApplyResult = PatchApplyResultT!string;
+
 /**
  * Merge a set of patches onto the text.  Return a patched text, as well
  * as an array of true/false values indicating which patches were applied.
- * @param patches Array of Patch objects
+ * @param patches Array of PatchT objects
  * @param text Old text.
  * @return Two element Object array, containing the new text and an array of
  *      bool values.
  */
 
- struct PatchApplyResult {
- 	wstring text;
+struct PatchApplyResultT(Str) {
+ 	Str text;
  	bool[] patchesApplied;
- }
+}
 
- PatchApplyResult apply(Patch[] patches, wstring text)
- {
- 	PatchApplyResult result;
- 	if( patches.length == 0 ) return result;
+PatchApplyResultT!Str apply(Str)(PatchT!(Str)[] patches, Str text)
+{
+    PatchApplyResultT!Str result;
+    if( patches.length == 0 ) return result;
 
- 	auto nullPadding = addPadding(patches);
+    auto nullPadding = addPadding(patches);
  	text = nullPadding ~ text ~ nullPadding;
  	splitMax(patches);
 
@@ -305,7 +308,7 @@ Patch[] patch_make(wstring text1, Diff[] diffs)
 			// Found a match. :)
 			result.patchesApplied[x] = true;
 			delta = start_loc - expected_loc;
-			wstring text2;
+			Str text2;
 			if( end_loc == -1 ){
 				text2 = text[ start_loc .. min(start_loc + text1.length, text.length) ];
 			} else {
@@ -313,7 +316,7 @@ Patch[] patch_make(wstring text1, Diff[] diffs)
 			}
 			if( text1 == text2 ) {
 				// Perfect match, just shove the replacement text in.
-				text = text.substr(0, start_loc) ~ diff_text2(patch.diffs) ~ text.substr(start_loc + text1.length);			
+				text = text.substr(0, start_loc) ~ diff_text2(patch.diffs) ~ text.substr(start_loc + text1.length);
 			} else {
 				// Imperfect match. Run a diff to get a framework of equivalent indices.
 				auto diffs = diff_main(text1, text2, false);
@@ -342,7 +345,7 @@ Patch[] patch_make(wstring text1, Diff[] diffs)
 			}
 		}
 		x++;
-	} 
+	}
 	// Strip the padding off.
 	result.text = text.substr(nullPadding.length, text.length - 2 * nullPadding.length);
 	return result;
@@ -351,13 +354,13 @@ Patch[] patch_make(wstring text1, Diff[] diffs)
 /**
  * Add some padding on text start and end so that edges can match something.
  * Intended to be called only from within patch_apply.
- * @param patches Array of Patch objects.
+ * @param patches Array of PatchT objects.
  * @return The padding string added to each side.
  */
-wstring addPadding(Patch[] patches)
+Str addPadding(Str)(PatchT!(Str)[] patches)
 {
 	auto paddingLength = PATCH_MARGIN;
-	wstring nullPadding;
+	Str nullPadding;
 	for(sizediff_t x = 1; x <= paddingLength; x++){
 		nullPadding ~= cast(char)x;
 	}
@@ -369,20 +372,20 @@ wstring addPadding(Patch[] patches)
 	}
 
 	// Add some padding on start of first diff.
-	Patch patch = patches[0];
+	PatchT!Str patch = patches[0];
 	auto diffs = patch.diffs;
 	if( diffs.length == 0 || diffs[0].operation != Operation.EQUAL ){
 		// Add nullPadding equality.
-		diffs.insert(0, [Diff(Operation.EQUAL, nullPadding)]);
+		diffs.insert(0, [DiffT!Str(Operation.EQUAL, nullPadding)]);
 		patch.start1 -= paddingLength;  // Should be 0.
 		patch.start2 -= paddingLength;  // Should be 0.
 		patch.length1 += paddingLength;
 		patch.length2 += paddingLength;
 	} else if (paddingLength > diffs[0].text.length) {
 		// Grow first equality.
-		Diff firstDiff = diffs[0];
-		auto extraLength = paddingLength - firstDiff.text.length;
-		firstDiff.text = nullPadding.substr(firstDiff.text.length) ~ firstDiff.text;
+		DiffT!Str firstDiffT = diffs[0];
+		auto extraLength = paddingLength - firstDiffT.text.length;
+		firstDiffT.text = nullPadding.substr(firstDiffT.text.length) ~ firstDiffT.text;
 		patch.start1 -= extraLength;
 		patch.start2 -= extraLength;
 		patch.length1 += extraLength;
@@ -394,14 +397,14 @@ wstring addPadding(Patch[] patches)
 	diffs = patch.diffs;
 	if( diffs.length == 0 || diffs[$-1].operation != Operation.EQUAL) {
 		// Add nullPadding equality.
-		diffs ~= Diff(Operation.EQUAL, nullPadding);
+		diffs ~= DiffT!Str(Operation.EQUAL, nullPadding);
 		patch.length1 += paddingLength;
 		patch.length2 += paddingLength;
 	} else if (paddingLength > diffs[$-1].text.length) {
 		// Grow last equality.
-		Diff lastDiff = diffs[$-1];
-		auto extraLength = paddingLength - lastDiff.text.length;
-		lastDiff.text ~= nullPadding.substr(0, extraLength);
+		DiffT!Str lastDiffT = diffs[$-1];
+		auto extraLength = paddingLength - lastDiffT.text.length;
+		lastDiffT.text ~= nullPadding.substr(0, extraLength);
 		patch.length1 += extraLength;
 		patch.length2 += extraLength;
 	}
@@ -412,26 +415,26 @@ wstring addPadding(Patch[] patches)
  * Look through the patches and break up any which are longer than the
  * maximum limit of the match algorithm.
  * Intended to be called only from within patch_apply.
- * @param patches List of Patch objects.
+ * @param patches List of PatchT objects.
  */
-void splitMax(Patch[] patches)
+void splitMax(Str)(PatchT!(Str)[] patches)
 {
 	auto patch_size = MATCH_MAXBITS;
 	for( auto x = 0; x < patches.length; x++ ){
 		if( patches[x].length1 <= patch_size ) continue;
-		Patch bigpatch = patches[x];
+		PatchT!Str bigpatch = patches[x];
 		patches.splice(x--, 1);
 		auto start1 = bigpatch.start1;
 		auto start2 = bigpatch.start2;
-		wstring precontext;
+		Str precontext;
 		while( bigpatch.diffs.length != 0){
-			Patch patch;
+			PatchT!Str patch;
 			bool empty = true;
 			patch.start1 = start1 - precontext.length;
 			patch.start2 = start2 - precontext.length;
 			if( precontext.length != 0 ){
 				patch.length1 = patch.length2 = precontext.length;
-				patch.diffs ~= Diff(Operation.EQUAL, precontext);
+				patch.diffs ~= DiffT!Str(Operation.EQUAL, precontext);
 			}
 			while( bigpatch.diffs.length != 0 && patch.length1 < patch_size - PATCH_MARGIN ){
 				Operation diff_type = bigpatch.diffs[0].operation;
@@ -450,7 +453,7 @@ void splitMax(Patch[] patches)
               		patch.length1 += diff_text.length;
               		start1 += diff_text.length;
               		empty = false;
-              		patch.diffs ~= Diff(diff_type, diff_text);
+              		patch.diffs ~= DiffT!Str(diff_type, diff_text);
               		bigpatch.diffs.remove(0);
 				} else {
 					// Deletion or equality. Only takes as much as we can stomach.
@@ -463,7 +466,7 @@ void splitMax(Patch[] patches)
 					} else {
 						empty = false;
 					}
-					patch.diffs ~= Diff(diff_type, diff_text);
+					patch.diffs ~= DiffT!Str(diff_type, diff_text);
 					if( diff_text == bigpatch.diffs[0].text ){
 						bigpatch.diffs.remove(0);
 					} else {
@@ -483,12 +486,12 @@ void splitMax(Patch[] patches)
 			if( postcontext.length != 0 ){
 				patch.length1 += postcontext.length;
 				patch.length2 += postcontext.length;
-				if( patch.diffs.length != 0 
+				if( patch.diffs.length != 0
 					&& patch.diffs[patch.diffs.length - 1].operation
 					== Operation.EQUAL) {
 					patch.diffs[$].text ~= postcontext;
 				} else {
-					patch.diffs ~= Diff(Operation.EQUAL, postcontext);
+					patch.diffs ~= DiffT!Str(Operation.EQUAL, postcontext);
 				}
 			}
 			if( !empty ){
@@ -500,41 +503,41 @@ void splitMax(Patch[] patches)
 
 /**
  * Take a list of patches and return a textual representation.
- * @param patches List of Patch objects.
+ * @param patches List of PatchT objects.
  * @return Text representation of patches.
  */
-public string patch_toText(in Patch[] patches)
+public string patch_toText(Str)(in PatchT!(Str)[] patches)
 {
-	auto text = appender!string();
-	foreach (aPatch; patches)
-		text ~= aPatch.toString();
+	auto text = appender!Str();
+	foreach (aPatchT; patches)
+		text ~= aPatchT.toString();
 	return text.data;
 }
 
 /**
- * Parse a textual representation of patches and return a List of Patch
+ * Parse a textual representation of patches and return a List of PatchT
  * objects.
  * @param textline Text representation of patches.
- * @return List of Patch objects.
+ * @return List of PatchT objects.
  * @throws ArgumentException If invalid input.
  */
-public Patch[] patch_fromText(string textline)
+public PatchT!(Str)[] patch_fromText(Str)(Str textline)
 {
 	import std.regex : regex, matchFirst;
 	import std.string : format, split;
 
-	auto patches = appender!(Patch[])();
+	auto patches = appender!(PatchT!(Str)[])();
 	if (textline.length == 0) return null;
 
 	auto text = textline.split("\n");
 	sizediff_t textPointer = 0;
 	auto patchHeader = regex("^@@ -(\\d+),?(\\d*) \\+(\\d+),?(\\d*) @@$");
-	char sign;
-	string line;
+	Unqual!(ElementEncodingType!Str) sign;
+	Str line;
 	while (textPointer < text.length) {
 		auto m = matchFirst(text[textPointer], patchHeader);
 		enforce (m, "Invalid patch string: " ~ text[textPointer]);
-		Patch patch;
+		PatchT!Str patch;
 		patch.start1 = m[1].to!sizediff_t;
 		if (m[2].length == 0) {
 			patch.start1--;
@@ -571,13 +574,13 @@ public Patch[] patch_fromText(string textline)
 			line = decodeComponent(line);
 			if (sign == '-') {
 				// Deletion.
-				patch.diffs ~= Diff(Operation.DELETE, line);
+				patch.diffs ~= DiffT!Str(Operation.DELETE, line);
 			} else if (sign == '+') {
 				// Insertion.
-				patch.diffs ~= Diff(Operation.INSERT, line);
+				patch.diffs ~= DiffT!Str(Operation.INSERT, line);
 			} else if (sign == ' ') {
 				// Minor equality.
-				patch.diffs ~= Diff(Operation.EQUAL, line);
+				patch.diffs ~= DiffT!Str(Operation.EQUAL, line);
 			} else if (sign == '@') {
 				// Start of next patch.
 				break;

--- a/source/ddmp/patch.d
+++ b/source/ddmp/patch.d
@@ -105,6 +105,8 @@ void addContext(Str)(ref PatchT!Str patch, Str text)
 {
 	if( text.length == 0 ) return;
 
+    import std.stdio : writeln;
+    writeln("addContext 0: patch=", patch, ", text=", text);
 	auto pattern = text.substr(patch.start2, patch.length1);
 	sizediff_t padding = 0;
 
@@ -121,12 +123,17 @@ void addContext(Str)(ref PatchT!Str patch, Str text)
 	// Add the prefix.
 	auto prefix = text[max(0, patch.start2 - padding)..patch.start2];
 	if( prefix.length != 0 ){
+        import std.stdio;
+        writeln("patch.addContext 2: prefix=", prefix);
 		patch.diffs.insert(0, [DiffT!Str(Operation.EQUAL, prefix)]);
 	}
 
 	// Add the suffix.
 	auto suffix = text[patch.start2 + patch.length1..min(text.length, patch.start2 + patch.length1 + padding)];
 	if( suffix.length != 0 ){
+        import std.stdio;
+        writeln("patch.addContext 3: text=", text);
+        writeln("patch.addContext 3: suffix=", suffix);
 		patch.diffs ~= DiffT!Str(Operation.EQUAL, suffix);
 	}
 
@@ -180,6 +187,8 @@ if (isSomeString!Str) {
  */
 PatchT!(Str)[] patch_make(Str)(Str text1, DiffT!(Str)[] diffs)
 {
+    import std.stdio : writeln;
+    writeln("patch_make 0: text1=", text1, ", diffs=", diffs);
 	PatchT!(Str)[] patches;
 	if( diffs.length == 0 ) return patches;
 
@@ -212,13 +221,16 @@ PatchT!(Str)[] patch_make(Str)(Str text1, DiffT!(Str)[] diffs)
 				break;
 			case Operation.EQUAL:
 				if( diff.text.length <= 2 * PATCH_MARGIN && patch.diffs.length != 0 && diff != diffs[$-1] ){
+                    writeln("patch_make 3: EQUAL 1");
 					patch.diffs ~= diff;
 					patch.length1 += diff.text.length;
 					patch.length2 += diff.text.length;
 				}
 
 				if( diff.text.length >= 2 * PATCH_MARGIN ){
+                    writeln("patch_make 3: EQUAL 2");
 					if( patch.diffs.length != 0 ){
+                        writeln("patch_make 3: EQUAL 3");
 						addContext(patch, prepatch_text);
 						patches ~= patch;
 						patch = PatchT!Str();
@@ -230,10 +242,12 @@ PatchT!(Str)[] patch_make(Str)(Str text1, DiffT!(Str)[] diffs)
 		}
         // Update the current character count.
         if (diff.operation != Operation.INSERT) {
-          char_count1 += diff.text.length;
+            writeln("patch_make 5: INSERT diff.text.length=", diff.text.length);
+            char_count1 += diff.text.length;
         }
         if (diff.operation != Operation.DELETE) {
-          char_count2 += diff.text.length;
+            writeln("patch_make 5: DELETE diff.text.length=", diff.text.length);
+            char_count2 += diff.text.length;
         }
     }
 	// Pick up the leftover patch if not empty.

--- a/source/ddmp/util.d
+++ b/source/ddmp/util.d
@@ -22,9 +22,11 @@
  */
 module ddmp.util;
 
-import std.string:indexOf;
+import std.traits : isSomeString;
+import std.string : indexOf;
 
-string substr(string str, size_t start, size_t len = size_t.max) {
+Range substr(Range)(Range str, size_t start, size_t len = size_t.max)
+if (isSomeString!Range) {
     auto end = len == size_t.max ? str.length : start + len;
     if (start >= str.length) {
         return "";
@@ -35,7 +37,8 @@ string substr(string str, size_t start, size_t len = size_t.max) {
     return str[start..end];
 }
 
-sizediff_t indexOfAlt(string str, string search, sizediff_t offset=0) {
+sizediff_t indexOfAlt(Range)(Range str, Range search, sizediff_t offset=0)
+if (isSomeString!Range) {
     auto index = str[offset..$].indexOf(search);
     if (index > -1 ) return index + offset;
     return -1;

--- a/test/source/app.d
+++ b/test/source/app.d
@@ -735,20 +735,6 @@ void testPatchMake() {
   auto patches = patch_make("", "");
   assertEquals("", patch_toText(patches));
 
-  /// DEBUGGING BEGIN
-  auto text3 = "Bot";
-  auto text4 = "Bet";
-  patches = patch_make(text3, text4);
-  import std.stdio;
-  writeln("patches.length=", patches.length);
-  writeln("patches[0].diffs=", patches[0].diffs);
-  writeln("patches[0].start1=", patches[0].start1);
-  writeln("patches[0].start2=", patches[0].start2);
-  writeln("patches[0].length1=", patches[0].length1);
-  writeln("patches[0].length2=", patches[0].length2);
-  assertEquals("hambocrab", patch_toText(patches));
-  /// DEBUGGING END
-
   auto text1 = "The quick brown fox jumps over the lazy dog.";
   auto text2 = "That quick brown fox jumped over a lazy dog.";
   // Text2+Text1 inputs.
@@ -794,8 +780,8 @@ void testPatchMake() {
   patches = patch_make(text1, text2);
   assertEquals(expectedPatch, patch_toText(patches));
 
-  // Test null inputs.
-  assertThrown(patch_make!string(null));
+  // (Don't) Test null inputs. (not needed in D because null is a valid empty string)
+  //assertThrown(patch_make!string(null));
 }
 
 void testPatchSplitMax() {

--- a/test/source/app.d
+++ b/test/source/app.d
@@ -735,6 +735,20 @@ void testPatchMake() {
   auto patches = patch_make("", "");
   assertEquals("", patch_toText(patches));
 
+  /// DEBUGGING BEGIN
+  auto text3 = "Bot";
+  auto text4 = "Bet";
+  patches = patch_make(text3, text4);
+  import std.stdio;
+  writeln("patches.length=", patches.length);
+  writeln("patches[0].diffs=", patches[0].diffs);
+  writeln("patches[0].start1=", patches[0].start1);
+  writeln("patches[0].start2=", patches[0].start2);
+  writeln("patches[0].length1=", patches[0].length1);
+  writeln("patches[0].length2=", patches[0].length2);
+  assertEquals("hambocrab", patch_toText(patches));
+  /// DEBUGGING END
+
   auto text1 = "The quick brown fox jumps over the lazy dog.";
   auto text2 = "That quick brown fox jumped over a lazy dog.";
   // Text2+Text1 inputs.

--- a/test/source/app.d
+++ b/test/source/app.d
@@ -103,14 +103,14 @@ void testDiffHalfMatch() {
 		HalfMatch hm_cmp, hm;
 		hm.prefix1 = "abc"; hm.suffix1 = "z"; hm.prefix2 ="1234"; hm.suffix2 = "0"; hm.commonMiddle = "56789";
 		assert(halfMatch("abc56789z", "1234567890", hm_cmp));
-		assert(hm == hm_cmp);		
+		assert(hm == hm_cmp);
 	}
 
 	{
 		HalfMatch hm_cmp, hm;
 		hm.prefix1 = "a"; hm.suffix1 = "xyz"; hm.prefix2 ="1"; hm.suffix2 = "7890"; hm.commonMiddle = "23456";
 		assert(halfMatch("a23456xyz", "1234567890", hm_cmp));
-		assert(hm == hm_cmp);		
+		assert(hm == hm_cmp);
 	}
 
   // Multiple Matches.
@@ -118,21 +118,21 @@ void testDiffHalfMatch() {
     HalfMatch hm_cmp, hm;
     hm.prefix1 = "12123"; hm.suffix1 = "123121"; hm.prefix2 ="a"; hm.suffix2 = "z"; hm.commonMiddle = "1234123451234";
     assert(halfMatch("121231234123451234123121", "a1234123451234z", hm_cmp));
-    assert(hm == hm_cmp);   
+    assert(hm == hm_cmp);
   }
 
   {
     HalfMatch hm_cmp, hm;
     hm.prefix1 = ""; hm.suffix1 = "-=-=-=-=-="; hm.prefix2 ="x"; hm.suffix2 = ""; hm.commonMiddle = "x-=-=-=-=-=-=-=";
     assert(halfMatch("x-=-=-=-=-=-=-=-=-=-=-=-=", "xx-=-=-=-=-=-=-=", hm_cmp));
-    assert(hm == hm_cmp);   
+    assert(hm == hm_cmp);
   }
 
   {
     HalfMatch hm_cmp, hm;
     hm.prefix1 = "-=-=-=-=-="; hm.suffix1 = ""; hm.prefix2 = ""; hm.suffix2 = "y"; hm.commonMiddle = "-=-=-=-=-=-=-=y";
     assert(halfMatch("-=-=-=-=-=-=-=-=-=-=-=-=y", "-=-=-=-=-=-=-=yy", hm_cmp));
-    assert(hm == hm_cmp);   
+    assert(hm == hm_cmp);
   }
 }
 
@@ -239,12 +239,12 @@ void testDiffCleanupMerge() {
 
 void testDiffCleanupSemanticLossless() {
   // Slide diffs to match logical boundaries.
-  {  
+  {
     // Null case.
     Diff[] diffs = [];
     cleanupSemanticLossless(diffs);
     assert([] == diffs);
-  } 
+  }
   /*{
     // Blank lines.
     Diff[] diffs = [Diff(Operation.EQUAL, "AAA\r\n\r\nBBB"), Diff(Operation.INSERT, "\r\nDDD\r\n\r\nBBB"), Diff(Operation.EQUAL, "\r\nEEE")];
@@ -563,7 +563,21 @@ void testDiffMain() {
       a ~= "1234567890" ~ to!string(x) ~ "\n";
       b ~= "abcdefghij" ~ to!string(x) ~ "\n";
   }
-  assertEquals(diff_main(a, b, false), diff_main(a, b, true));
+  try {
+      assertEquals(diff_main(a, b, false), diff_main(a, b, true));
+      assert(false, "Expected exception when unique lines exceeds UTF-8 encoding space.");
+  } catch (Exception e) {
+      // ignore
+  }
+
+  // Test using UTF-16 to handle cases when UTF-8 would run out of space.
+  wstring a2 = "";
+  wstring b2 = "";
+  foreach (x; 0 .. 500) {
+      a2 ~= "1234567890" ~ to!wstring(x) ~ "\n";
+      b2 ~= "abcdefghij" ~ to!wstring(x) ~ "\n";
+  }
+  assertEquals(diff_main(a2, b2, false), diff_main(a2, b2, true));
 
   // (Don't) Test null inputs (not needed in D, because null is a valid empty string)
   //assertThrown(diff_main(null, null));
@@ -767,7 +781,7 @@ void testPatchMake() {
   assertEquals(expectedPatch, patch_toText(patches));
 
   // Test null inputs.
-  assertThrown(patch_make(null));
+  assertThrown(patch_make!string(null));
 }
 
 void testPatchSplitMax() {


### PR DESCRIPTION
Convert most methods to internally use UTF-16, like C++ QString, because 'linesToCharsMunge' stores line-index as characters, and as few as 128 lines causes UTF-8 multi-byte encoding, resulting in malformed results.

### Problem

Consider the following method: https://github.com/vnayar/ddmp/blob/342a1ab27ceeabccecc201994c9e4a72f731e437/source/ddmp/diff.d#L233

```
string linesToCharsMunge(string text, ref string[] lines, ref size_t[string] linehash)
{
    sizediff_t lineStart = 0;
    sizediff_t lineEnd = -1;
    string line;
    auto chars = appender!string();
    while( lineEnd+1 < text.length ){
        lineEnd = text.indexOfAlt("\n", lineStart);
        if( lineEnd == -1 ) lineEnd = text.length - 1;
        line = text[lineStart..lineEnd + 1];
        lineStart = lineEnd + 1;

        if (auto pv = line in linehash) {
            chars ~= cast(dchar)*pv;
        } else {
            lines ~= line;
            linehash[line] = lines.length - 1;
            chars ~= cast(dchar)(lines.length -1);    // The unique line number is stored as a character.
        }
    }
    return chars.data();
}
```

This method will store multi-byte or invalid UTF-8 characters if there are more than 128 unique lines of text. A multi-byte character cannot be correctly interpreted by other methods like `commonPrefix` and `commonSuffix`, among others.

### Solution

Convert most methods to internally use `wstring`, which more closely matches the C++ implementation here: https://github.com/google/diff-match-patch/blob/62f2e689f498f9c92dbc588c58750addec9b1654/cpp/diff_match_patch.cpp#L523
This implementation uses QString, which is based on a UTF-16 encoding: https://doc.qt.io/qt-6/qstring.html

This representation greatly increases the size of files that can be supported by these methods.

UTF conversion methods were used to preserve as many public interfaces as possible.