### PR TITLE
Fix UTF-8/16 behavior of common(Prefix/Suffix/Overlap)

### DIFF
--- a/source/ddmp/diff.d
+++ b/source/ddmp/diff.d
@@ -362,6 +362,7 @@ private size_t utfStride(Str)(Str text)
     //       parts of the diff algorithm are UTF correct, yet. For this
     //       reason, 1 is returned, so that the rest of the algorithm can
     //       continue to work as usual
+    assert(text.length > 0);
     try return text.stride;
     catch (UTFException e) return 1;
 }
@@ -373,6 +374,7 @@ private size_t utfStrideBack(Str)(Str text)
     //       parts of the diff algorithm are UTF correct, yet. For this
     //       reason, 1 is returned, so that the rest of the algorithm can
     //       continue to work as usual
+    assert(text.length > 0);
     try return text.strideBack;
     catch (UTFException e) return 1;
 }

--- a/source/ddmp/diff.d
+++ b/source/ddmp/diff.d
@@ -710,7 +710,8 @@ DiffT!(Str)[] diff_lineMode(Str)(Str text1, Str text2, SysTime deadline)
         }
         pointer++;
     }
-    diffs.remove(diffs.length - 1);
+
+    diffs = diffs[0 .. $-1];
     return diffs;
 }
 
@@ -721,12 +722,10 @@ DiffT!(Str)[] bisect(Str)(Str text1, Str text2, SysTime deadline)
     auto max_d = (text1_len + text2_len + 1) / 2;
     auto v_offset = max_d;
     auto v_len = 2 * max_d;
-    sizediff_t[] v1;
-    sizediff_t[] v2;
-    for( auto x = 0; x < v_len; x++ ){
-        v1 ~= -1;
-        v2 ~= -1;
-    }
+    auto v1 = new sizediff_t[](v_len);
+    auto v2 = new sizediff_t[](v_len);
+    v1[] = -1;
+    v2[] = -1;
     v1[v_offset + 1] = 0;
     v2[v_offset + 1] = 0;
     auto delta = text1_len - text2_len;
@@ -804,10 +803,11 @@ DiffT!(Str)[] bisect(Str)(Str text1, Str text2, SysTime deadline)
             }
         }
     }
-    DiffT!(Str)[] diffs;
-    diffs ~= DiffT!Str(Operation.DELETE, text1);
-    diffs ~= DiffT!Str(Operation.INSERT, text2);
-    return diffs;
+
+    return [
+        DiffT!Str(Operation.DELETE, text1),
+        DiffT!Str(Operation.INSERT, text2)
+    ];
 }
 
 

--- a/source/ddmp/diff.d
+++ b/source/ddmp/diff.d
@@ -26,7 +26,6 @@ import ddmp.util;
 
 import std.array;
 import std.conv;
-import std.datetime : SysTime, Clock, UTC;
 import std.exception : enforce;
 import std.string : indexOf, endsWith, startsWith;
 import std.uni;
@@ -455,11 +454,11 @@ DiffT!(Str)[] diff_main(Str)(Str text1, Str text2)
 DiffT!(Str)[] diff_main(Str)(Str text1, Str text2, bool checklines)
 {
     // Set a deadline by which time the diff must be complete.
-    SysTime deadline;
+    MonoTime deadline;
     if (diffTimeout <= 0.seconds) {
-        deadline = SysTime.max;
+        deadline = MonoTime.max;
     } else {
-        deadline = Clock.currTime(UTC()) + diffTimeout;
+        deadline = MonoTime.currTime + diffTimeout;
     }
     return diff_main(text1, text2, checklines, deadline);
 }
@@ -477,7 +476,7 @@ DiffT!(Str)[] diff_main(Str)(Str text1, Str text2, bool checklines)
  *     instead.
  * @return List of DiffT objects.
  */
-DiffT!(Str)[] diff_main(Str)(Str text1, Str text2, bool checklines, SysTime deadline)
+DiffT!(Str)[] diff_main(Str)(Str text1, Str text2, bool checklines, MonoTime deadline)
 {
     DiffT!(Str)[] diffs;
     if( text1 == text2 ){
@@ -617,7 +616,7 @@ bool halfMatchI(Str)(Str longtext, Str shorttext, sizediff_t i, out HalfMatchT!S
  * @param deadline Time when the diff should be complete by.
  * @return List of DiffT objects.
  */
-DiffT!(Str)[] computeDiffTs(Str)(Str text1, Str text2, bool checklines, SysTime deadline)
+DiffT!(Str)[] computeDiffTs(Str)(Str text1, Str text2, bool checklines, MonoTime deadline)
 {
     DiffT!(Str)[] diffs;
 
@@ -665,7 +664,7 @@ DiffT!(Str)[] computeDiffTs(Str)(Str text1, Str text2, bool checklines, SysTime 
     return bisect(text1, text2, deadline);
 }
 
-DiffT!(Str)[] diff_lineMode(Str)(Str text1, Str text2, SysTime deadline)
+DiffT!(Str)[] diff_lineMode(Str)(Str text1, Str text2, MonoTime deadline)
 {
     auto b = linesToChars(text1, text2);
 
@@ -715,7 +714,7 @@ DiffT!(Str)[] diff_lineMode(Str)(Str text1, Str text2, SysTime deadline)
     return diffs;
 }
 
-DiffT!(Str)[] bisect(Str)(Str text1, Str text2, SysTime deadline)
+DiffT!(Str)[] bisect(Str)(Str text1, Str text2, MonoTime deadline)
 {
     auto text1_len = text1.length;
     auto text2_len = text2.length;
@@ -736,7 +735,7 @@ DiffT!(Str)[] bisect(Str)(Str text1, Str text2, SysTime deadline)
     auto k2end = 0;
     for( auto d = 0; d < max_d; d++ ){
         // Bail out if deadline is reached.
-        if (Clock.currTime(UTC()) > deadline) {
+        if (MonoTime.currTime - deadline > Duration.zero) {
             break;
         }
 
@@ -811,7 +810,7 @@ DiffT!(Str)[] bisect(Str)(Str text1, Str text2, SysTime deadline)
 }
 
 
-DiffT!(Str)[] bisectSplit(Str)(Str text1, Str text2, sizediff_t x, sizediff_t y, SysTime deadline)
+DiffT!(Str)[] bisectSplit(Str)(Str text1, Str text2, sizediff_t x, sizediff_t y, MonoTime deadline)
 {
     auto text1a = text1[0 .. x];
     auto text2a = text2[0 .. y];

--- a/source/ddmp/diff.d
+++ b/source/ddmp/diff.d
@@ -306,6 +306,8 @@ unittest {
     assert(commonPrefix("abcd", "abdd") == 2);
     assert(commonPrefix("abäd", "abäe") == 4);
     assert(commonPrefix("abä", "abö") == 2);
+    assert(commonPrefix("March", "März") == 1);
+    assert(commonPrefix("Atü", "Atu") == 2);
 }
 
 size_t commonSuffix(Str)(Str text1, Str text2)
@@ -327,6 +329,12 @@ unittest {
     assert(commonSuffix("acäd", "abäd") == 3);
     assert(commonSuffix("äbc", "öbc") == 2);
     assert(commonSuffix("äbc", "öbc") == 2);
+    assert(commonSuffix("über", "uber") == 3);
+    assert(commonSuffix("uber", "über") == 3);
+    // NOTE: the following two cases are equivalent
+    assert(commonSuffix("€", "À") == 0);
+    assert(commonSuffix(x"C280", x"C380") == 0);
+    assert(commonSuffix("€a", "Àa") == 1);
 }
 
 /**

--- a/source/ddmp/diff.d
+++ b/source/ddmp/diff.d
@@ -644,9 +644,10 @@ unittest {
     assert(isValidSequence("ö"));
     assert(!isValidSequence("ö"[0 .. 1]));
     assert(!isValidSequence("ö"[1 .. 2]));
-    assert(isValidSequence("\U0001FA01"w));
-    assert(!isValidSequence("\U0001FA01"w[0 .. 1]));
-    assert(!isValidSequence("\U0001FA01"w[1 .. 2]));
+    wstring test = "\U0001FA01"w;
+    assert(isValidSequence(test));
+    assert(!isValidSequence(test[0 .. 1]));
+    assert(!isValidSequence(test[1 .. 2]));
 }
 
 bool halfMatchI(Str)(Str longtext, Str shorttext, sizediff_t i, out HalfMatchT!Str hm){

--- a/test/source/app.d
+++ b/test/source/app.d
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright 2008 Google Inc. All Rights Reserved.
  * Copyright 2013-2014 Jan Krüger. All Rights Reserved.
  * Author: fraser@google.com (Neil Fraser)
@@ -27,7 +27,6 @@ import ddmp.patch;
 import ddmp.match;
 
 import core.time;
-import std.datetime;
 import std.exception;
 import std.stdio;
 
@@ -466,10 +465,10 @@ void testDiffBisect() {
   // Since the resulting diff hasn't been normalized, it would be ok if
   // the insertion and deletion pairs are swapped.
   // If the order changes, tweak this test as required.
-  assertEquals([Diff(Operation.DELETE, "c"), Diff(Operation.INSERT, "m"), Diff(Operation.EQUAL, "a"), Diff(Operation.DELETE, "t"), Diff(Operation.INSERT, "p")], bisect(a, b, SysTime.max));
+  assertEquals([Diff(Operation.DELETE, "c"), Diff(Operation.INSERT, "m"), Diff(Operation.EQUAL, "a"), Diff(Operation.DELETE, "t"), Diff(Operation.INSERT, "p")], bisect(a, b, MonoTime.max));
 
   // Timeout.
-  assertEquals([Diff(Operation.DELETE, "cat"), Diff(Operation.INSERT, "map")], bisect(a, b, SysTime(0)));
+  assertEquals([Diff(Operation.DELETE, "cat"), Diff(Operation.INSERT, "map")], bisect(a, b, MonoTime(0)));
 }
 
 void testDiffMain() {
@@ -521,9 +520,9 @@ void testDiffMain() {
     a = a ~ a;
     b = b ~ b;
   }
-  auto startTime = Clock.currTime(UTC());
+  auto startTime = MonoTime.currTime;
   diff_main(a, b);
-  auto endTime = Clock.currTime(UTC());
+  auto endTime = MonoTime.currTime;
   // Test that we took at least the timeout period.
   assert(diffTimeout <= endTime - startTime);
   // Test that we didn't take forever (be forgiving).

--- a/test/source/app.d
+++ b/test/source/app.d
@@ -573,6 +573,10 @@ void testDiffMain() {
   }
   assertEquals(diff_main(a2, b2, false), diff_main(a2, b2, true));
 
+  // Ensure UTF sequences do not get split up in diffs
+  assertEquals([Diff(Operation.EQUAL, "a"), Diff(Operation.DELETE, "€"), Diff(Operation.INSERT, "À"), Diff(Operation.EQUAL, "b")],
+    diff_main("a€b", "aÀb", false));
+
   // (Don't) Test null inputs (not needed in D, because null is a valid empty string)
   //assertThrown(diff_main(null, null));
 }

--- a/test/source/app.d
+++ b/test/source/app.d
@@ -562,12 +562,7 @@ void testDiffMain() {
       a ~= "1234567890" ~ to!string(x) ~ "\n";
       b ~= "abcdefghij" ~ to!string(x) ~ "\n";
   }
-  try {
-      assertEquals(diff_main(a, b, false), diff_main(a, b, true));
-      assert(false, "Expected exception when unique lines exceeds UTF-8 encoding space.");
-  } catch (Exception e) {
-      // ignore
-  }
+  assertEquals(diff_main(a, b, false), diff_main(a, b, true));
 
   // Test using UTF-16 to handle cases when UTF-8 would run out of space.
   wstring a2 = "";


### PR DESCRIPTION
To get proper diffs with no invalid UTF sequences in UTF-8 or UTF-16 mode, at least halfMatch is yet to be fixed in addition to these functions.